### PR TITLE
Updated the maven zip file version and README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ ansible-playbook restart_mock_trading_server.yaml --key-file ~/.ssh/virginia.pem
 # Start the HFT client
 ansible-playbook restart_hft_client.yaml --key-file ~/.ssh/virginia.pem -i ./inventory/inventory.aws_ec2.yml
 
+# Start the test run for desired duration
+ansible-playbook start_latency_test.yaml --key-file ~/.ssh/virginia.pem -i ./inventory/inventory.aws_ec2.yml
+
 # Let the test run for desired duration, then stop it
 ansible-playbook stop_latency_test.yaml --key-file ~/.ssh/virginia.pem -i ./inventory/inventory.aws_ec2.yml
 ```

--- a/deployment/ansible/provision_ec2.yaml
+++ b/deployment/ansible/provision_ec2.yaml
@@ -49,8 +49,8 @@
     become: yes
     become_user: root
     get_url:
-      url: "https://dlcdn.apache.org/maven/maven-3/3.9.7/binaries/apache-maven-3.9.7-bin.tar.gz"
-      dest: "/tmp/apache-maven-3.9.7-bin.tar.gz"
+      url: "https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz"
+      dest: "/tmp/apache-maven-3.9.11-bin.tar.gz"
       mode: '0644'
     register: maven_download
     
@@ -58,10 +58,10 @@
     become: yes
     become_user: root
     unarchive:
-      src: "/tmp/apache-maven-3.9.7-bin.tar.gz"
+      src: "/tmp/apache-maven-3.9.11-bin.tar.gz"
       dest: "/opt/maven"
       remote_src: yes
-      creates: "/opt/maven/apache-maven-3.9.7"
+      creates: "/opt/maven/apache-maven-3.9.11"
     when: maven_download is changed
     
   - name: Create Maven profile script
@@ -71,7 +71,7 @@
       dest: /etc/profile.d/maven.sh
       content: |
         #!/bin/bash
-        export MAVEN_HOME=/opt/maven/apache-maven-3.9.7
+        export MAVEN_HOME=/opt/maven/apache-maven-3.9.11
         export PATH=$MAVEN_HOME/bin:$PATH
       mode: '0755'
       
@@ -79,7 +79,7 @@
     become: yes
     become_user: root
     file:
-      src: /opt/maven/apache-maven-3.9.7/bin/mvn
+      src: /opt/maven/apache-maven-3.9.11/bin/mvn
       dest: /usr/bin/mvn
       state: link
       
@@ -207,7 +207,7 @@
     become: yes
     become_user: ec2-user
     shell: |
-      export MAVEN_HOME=/opt/maven/apache-maven-3.9.7
+      export MAVEN_HOME=/opt/maven/apache-maven-3.9.11
       export PATH=$MAVEN_HOME/bin:$PATH
       cd /home/ec2-user/hft-client
       mvn clean install


### PR DESCRIPTION
Updated the maven zip file version from 3.9.7 to 3.9.11. And added Benchmark start command in the README file

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/trading-latency-benchmark/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0
