### PR TITLE
Add OS-tuned AMI builder feature and enhance OS tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The benchmark suite consists of:
 2. **Rust Mock Trading Server**: A lightweight server that simulates a trading exchange by responding to client orders
 3. **CDK Infrastructure**: AWS CDK code to deploy the required EC2 instances and networking components
 4. **Ansible Playbooks**: Scripts to provision instances, run tests, and collect results
-5. **Analysis Tools**: Utilities to process and visualize latency data using HDR Histograms
+5. **OS-Tuned AMI Builder**: Automated pipeline to create pre-optimized Amazon Machine Images with performance tuning baked in
+6. **Analysis Tools**: Utilities to process and visualize latency data using HDR Histograms
 
 ### Sequence Diagram
 The benchmark contains a simple HFT client and Matching Engine written in Java to simulate a basic order flow sequence for latency measurements, as per the following diagram:
@@ -54,9 +55,37 @@ Before using this benchmark suite, ensure you have the following prerequisites:
 
 ## Getting Started
 
+### Option A: Quick Start with Pre-Built OS-Tuned AMI (Recommended)
+
+For fastest deployment and optimal performance, build a pre-tuned AMI first:
+
+```bash
+cd deployment
+./build-tuned-ami.sh --key-file ~/.ssh/virginia.pem
+```
+
+This creates an AMI with all OS-level optimizations pre-applied (CPU isolation, network tuning, hugepages, etc.). The process takes ~20-30 minutes but eliminates the need to run OS tuning on every deployment.
+
+**Important - CPU Allocation Considerations:**
+- CPU isolation settings are **baked into the AMI** at build time based on the builder instance's vCPU count
+- For optimal performance, build the AMI on the same instance type you plan to deploy to (or within the same size class)
+- Example: Building on c7i.4xlarge (16 vCPUs) then deploying on c7i.48xlarge (192 vCPUs) will only isolate 12 cores instead of 176
+- See the [AMI Builder README](deployment/AMI_BUILDER_README.md#building-amis-for-multiple-instance-types) for recommended build strategies
+
+Then deploy using the tuned AMI:
+
+```bash
+cd cdk
+cdk deploy --context deploymentType=cluster --context baseAmi=ami-xxxxxxxxx
+```
+
+See [deployment/AMI_BUILDER_README.md](deployment/AMI_BUILDER_README.md) for detailed AMI builder documentation.
+
+### Option B: Standard Deployment with Manual OS Tuning
+
 ### 1. Deploy Infrastructure with CDK
 
-First, deploy the required AWS infrastructure using CDK. You have several deployment options:
+Deploy the required AWS infrastructure using CDK. You have several deployment options:
 
 #### Default Single Instance Deployment
 
@@ -90,6 +119,23 @@ To test latency across multiple availability zones:
 cd deployment/cdk
 npm install
 cdk deploy --context deploymentType=multi-az
+```
+
+#### AMI Builder Deployment
+
+To build an OS-tuned AMI for reuse across deployments:
+
+```bash
+cd deployment/cdk
+npm install
+cdk deploy --context deploymentType=ami-builder --context instanceType=c7i.4xlarge
+```
+
+Or use the automated build script (recommended):
+
+```bash
+cd deployment
+./build-tuned-ami.sh --instance-type c7i.4xlarge --key-file ~/.ssh/virginia.pem
 ```
 
 These commands will create EC2 instances in your AWS account according to the selected architecture.
@@ -149,14 +195,40 @@ These metrics help identify not just average performance but also worst-case sce
 
 ## Advanced Configuration
 
+### Pre-Built OS-Tuned AMIs
+
+For production deployments, we recommend using pre-built OS-tuned AMIs:
+
+**Benefits:**
+- **Faster Deployments**: Skip 10-15 minute OS tuning process on every deployment
+- **Consistency**: Guaranteed identical OS optimizations across all instances
+- **Immutable Infrastructure**: Version-controlled tuning configurations via AMI tags
+- **Dynamic Scaling**: CPU isolation automatically adapts to instance size (2-192 vCPUs supported)
+
+**Build Strategy:**
+Build separate AMIs for different instance size classes for optimal performance:
+- Small (4-8 vCPUs): Build on c7i.2xlarge
+- Medium (16-32 vCPUs): Build on c7i.4xlarge
+- Large (48-96 vCPUs): Build on c7i.24xlarge
+- X-Large (128-192 vCPUs): Build on c7i.48xlarge
+
+See [deployment/AMI_BUILDER_README.md](deployment/AMI_BUILDER_README.md) for complete documentation.
+
 ### Tuning OS Parameters
 
-The `tune_os.yaml` playbook applies various system-level optimizations:
+The `tune_os.yaml` playbook applies various system-level optimizations with **dynamic CPU core allocation**:
 
-- CPU frequency scaling and power management settings
-- Network stack parameters
-- IRQ affinity
-- NUMA settings
+**CPU Optimizations:**
+- Automatically detects vCPU count and scales housekeeping cores
+- Disables hyperthreading, C-states, and P-states
+- Sets CPU governor to performance
+- Isolates cores for trading applications (scales from 1 to 176 cores)
+- Moves IRQs and kernel workqueues to housekeeping cores
+
+**Other Optimizations:**
+- Network stack parameters (busy polling, TSO/GSO disabled)
+- Memory settings (hugepages, THP disabled, NUMA)
+- I/O scheduler configuration
 - Kernel parameters
 
 You can customize these settings in the playbook based on your specific requirements.
@@ -174,10 +246,13 @@ The Java client is launched with specific JVM parameters to optimize performance
 
 The benchmark implements several optimization techniques commonly used in high-frequency trading applications:
 
-1. **Thread Processor Affinity**: Pins threads to specific CPU cores to prevent cache thrashing
-2. **Composite Buffers**: Reduces unnecessary object allocations and copy operations
-3. **Separate Execution and IO Threads**: Keeps network I/O threads dedicated to communication
-4. **HDR Histogram for Latency Recording**: Efficiently records latency measurements with high precision
+1. **Dynamic CPU Isolation**: Automatically scales isolated cores based on instance size (supports 2-192 vCPUs)
+2. **Thread Processor Affinity**: Pins threads to specific CPU cores to prevent cache thrashing
+3. **Composite Buffers**: Reduces unnecessary object allocations and copy operations
+4. **Separate Execution and IO Threads**: Keeps network I/O threads dedicated to communication
+5. **HDR Histogram for Latency Recording**: Efficiently records latency measurements with high precision
+6. **io_uring Transport**: Uses Linux io_uring for zero-copy networking when available
+7. **OS-Level Tuning**: Network stack, memory management, and I/O scheduler optimizations
 
 ## Contributing
 

--- a/deployment/AMI_BUILDER_README.md
+++ b/deployment/AMI_BUILDER_README.md
@@ -1,0 +1,479 @@
+# OS-Tuned AMI Builder
+
+This directory contains tools to build pre-optimized Amazon Machine Images (AMIs) for low-latency trading applications. The AMI builder automates the process of deploying an EC2 instance, applying comprehensive OS-level performance tuning, and creating an immutable AMI that can be reused across all deployment types.
+
+## Overview
+
+The AMI builder consists of:
+- **CDK Stack** (`cdk/lib/ami-builder-stack.ts`): Deploys a single EC2 instance for AMI creation
+- **Build Script** (`build-tuned-ami.sh`): Orchestrates deployment, tuning, and AMI creation
+- **Ansible Playbook** (`ansible/tune_os.yaml`): Applies comprehensive OS optimizations
+
+## Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- AWS CDK installed and bootstrapped
+- Ansible 2.9+ installed
+- SSH key pair registered in AWS (default: `virginia`)
+- `jq` command-line JSON processor
+- Node.js 18+ (for CDK)
+- **Important**: The AMI builder instance tag must be included in `deployment/ansible/inventory/inventory.aws_ec2.yml`
+  - The instance is tagged as `Name: Trading-Benchmark-AMI-Builder-Instance`
+  - This tag must be in the `include_filters` section of the inventory file
+  - Already configured in the repository's inventory file
+
+### Installing jq
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install jq
+
+# macOS
+brew install jq
+
+# Amazon Linux/RHEL
+sudo yum install jq
+```
+
+## Quick Start
+
+Build an OS-tuned AMI with default settings:
+
+```bash
+cd deployment
+./build-tuned-ami.sh --key-file ~/.ssh/virginia.pem
+```
+
+This will:
+1. Deploy a c7i.4xlarge instance in us-east-1
+2. Verify instance is discoverable in Ansible dynamic inventory
+3. Apply all OS tuning optimizations via Ansible playbook
+4. Wait for automatic reboot
+5. Verify OS tuning was applied successfully:
+   - Check for tuning report file (`/root/trading_system_tuning_report.txt`)
+   - Verify Transparent Huge Pages disabled
+   - Verify CPU cores isolated
+   - Verify hugepages configured
+6. Create an AMI from the tuned instance
+7. Clean up the temporary instance
+
+Expected duration: **20-30 minutes**
+
+## Usage
+
+```bash
+./build-tuned-ami.sh [options]
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-i, --instance-type TYPE` | EC2 instance type to use | `c7i.4xlarge` |
+| `-k, --key-file PATH` | Path to SSH private key | `~/.ssh/virginia.pem` |
+| `-n, --ami-name NAME` | Custom AMI name | `trading-benchmark-tuned-TIMESTAMP` |
+| `-r, --region REGION` | AWS region | `us-east-1` |
+| `--no-cleanup` | Keep instance running after AMI creation | Cleanup enabled |
+| `-h, --help` | Show help message | - |
+
+### Examples
+
+**Build AMI with custom instance type:**
+```bash
+./build-tuned-ami.sh --instance-type c6in.4xlarge --key-file ~/.ssh/my-key.pem
+```
+
+**Build AMI with custom name:**
+```bash
+./build-tuned-ami.sh --ami-name my-trading-ami-v1 --key-file ~/.ssh/virginia.pem
+```
+
+**Build AMI and keep instance for inspection:**
+```bash
+./build-tuned-ami.sh --no-cleanup --key-file ~/.ssh/virginia.pem
+# Instance will remain running - remember to destroy the stack later:
+# cd cdk && cdk destroy TradingBenchmarkAmiBuilderStack
+```
+
+**Build AMI in different region:**
+```bash
+./build-tuned-ami.sh --region us-west-2 --key-file ~/.ssh/my-west-key.pem
+```
+
+## What Gets Tuned?
+
+The AMI builder applies the following optimizations from `tune_os.yaml`:
+
+### CPU Optimizations
+- Disables hyperthreading
+- Sets CPU governor to `performance`
+- Disables C-states and P-states
+- **Dynamic CPU isolation** based on instance size:
+  - Automatically detects vCPU count
+  - Scales housekeeping cores: 1 core (≤4 vCPUs), 2 cores (8 vCPUs), 4 cores (16-32 vCPUs), 8 cores (48-96 vCPUs), 16 cores (128-192 vCPUs)
+  - Isolates remaining cores for trading applications
+  - Supports instances up to 48xlarge (192 vCPUs)
+- Moves kernel workqueues to housekeeping cores
+- Sets TSC as clocksource
+
+### Memory Optimizations
+- Disables Transparent Huge Pages (THP)
+- Configures explicit hugepages
+- Sets VM dirty ratios for optimal I/O
+- Disables NUMA balancing
+- Configures shared memory limits for IPC
+
+### Network Optimizations
+- Disables hardware offloading (TSO, GSO, GRO)
+- Sets static interrupt moderation (1 µs)
+- Configures busy polling for lower latency
+- Optimizes TCP/IP stack parameters
+- Configures RSS and XPS for optimal packet processing
+- Increases network buffer sizes
+
+### I/O Optimizations
+- Sets mq-deadline I/O scheduler
+- Optimizes NVMe settings
+- Disables block layer statistics
+- Disables entropy collection from block devices
+
+### System Optimizations
+- Disables unnecessary services (irqbalance, SSM agent)
+- Disables iptables
+- Disables syscall auditing
+- Configures RT priorities for trading processes
+- Configures Chrony for precise time synchronization with AWS Time Sync Service
+
+### Persistence
+All optimizations persist across reboots via:
+- systemd services
+- sysctl configuration files
+- udev rules
+- GRUB kernel command-line parameters
+- rc.local boot script
+
+## Using the Tuned AMI
+
+After building, the script outputs an AMI ID. Use it in your deployments:
+
+### Option 1: CDK Context
+```bash
+cd cdk
+cdk deploy --context deploymentType=cluster --context baseAmi=ami-xxxxxxxxx
+```
+
+### Option 2: CDK Code
+Update your CDK stack to use the tuned AMI:
+
+```typescript
+import { MachineImage } from 'aws-cdk-lib/aws-ec2';
+
+const tunedAmi = MachineImage.genericLinux({
+  'us-east-1': 'ami-xxxxxxxxx'
+});
+
+const instance = new Instance(this, 'TradingInstance', {
+  // ... other props
+  machineImage: tunedAmi,
+});
+```
+
+### Option 3: Modify Existing Stacks
+The AMI builder stack supports a `baseAmi` context parameter. Update `single-instance-stack.ts`, `cluster-placement-group-stack.ts`, or `multi-az-stack.ts` to accept and use this parameter.
+
+## Benefits
+
+### Faster Deployments
+- **Without AMI**: Deploy instance → Wait 5 min → Run tune_os.yaml → Wait 10-15 min → Reboot → Wait 5 min = **~25 minutes**
+- **With AMI**: Deploy instance from tuned AMI → Ready in **~2 minutes**
+
+### Consistency
+- All instances guaranteed to have identical OS-level optimizations
+- No risk of missing tuning steps or misconfiguration
+- Immutable infrastructure pattern
+
+### Version Control
+- Tag AMIs with different tuning configurations
+- Roll back to previous tuning versions if needed
+- Track which AMI version is deployed where
+
+### Cost Optimization
+- Reduce time-to-production for new instances
+- Minimize time spent tuning instances during testing
+- AMI storage cost is negligible (~$0.05/month per GB)
+
+## Verification
+
+After creating an AMI, you can verify the optimizations:
+
+### 1. Deploy an instance from the AMI
+```bash
+cdk deploy --context deploymentType=single --context baseAmi=ami-xxxxxxxxx
+```
+
+### 2. SSH into the instance
+```bash
+ssh -i ~/.ssh/virginia.pem ec2-user@<instance-ip>
+```
+
+### 3. Run verification commands
+```bash
+# Check Transparent Huge Pages (should be "never")
+cat /sys/kernel/mm/transparent_hugepage/enabled
+
+# Check CPU isolation (should show isolated cores)
+cat /sys/devices/system/cpu/isolated
+
+# Check hugepages
+grep Huge /proc/meminfo
+
+# Check CPU governor (should be "performance")
+cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+
+# Check I/O scheduler (should be "mq-deadline" or "[mq-deadline]")
+cat /sys/block/nvme0n1/queue/scheduler
+
+# Check kernel command line (should include isolcpus, nohz_full, etc.)
+cat /proc/cmdline
+
+# View full tuning report
+cat /root/trading_system_tuning_report.txt
+```
+
+## Troubleshooting
+
+### Build fails at CDK deploy step
+- Ensure AWS credentials are configured: `aws sts get-caller-identity`
+- Ensure CDK is bootstrapped: `cd cdk && cdk bootstrap`
+- Check that the key pair exists in AWS: `aws ec2 describe-key-pairs --key-names virginia`
+
+### Build fails at Ansible step
+
+**"Instance not found in dynamic inventory" error:**
+- The instance must have the tag `Name: Trading-Benchmark-AMI-Builder-Instance`
+- This tag must be in `deployment/ansible/inventory/inventory.aws_ec2.yml`
+- Check the inventory file includes:
+  ```yaml
+  include_filters:
+    - tag:Name:
+      - 'Trading-Benchmark-AMI-Builder-Instance'
+  ```
+
+**Other Ansible issues:**
+- Verify SSH key permissions: `chmod 400 ~/.ssh/virginia.pem`
+- Ensure security group allows SSH from your IP
+- Check Ansible is installed: `ansible --version`
+- Verify the instance tag exists: `aws ec2 describe-instances --instance-ids <instance-id> --query 'Reservations[0].Instances[0].Tags'`
+
+### Build fails at AMI creation
+- Ensure instance is stopped before AMI creation
+- Check AWS service limits for AMIs in the region
+- Verify IAM permissions include `ec2:CreateImage`
+
+### SSH timeout when waiting for instance
+- Check AWS console to verify instance is running
+- Verify instance has a public IP address
+- Ensure security group allows SSH (port 22) from your IP
+- Try increasing `MAX_WAIT_TIME` in the script
+
+### jq command not found
+```bash
+# Install jq
+sudo apt-get install jq  # Ubuntu/Debian
+brew install jq          # macOS
+sudo yum install jq      # Amazon Linux/RHEL
+```
+
+### OS tuning verification failures
+
+If you see warnings like "⚠ Hugepages not detected" or "⚠ CPU isolation not detected":
+- Some settings only take effect after a full reboot
+- The script creates the AMI after stopping the instance, which ensures settings persist
+- You can verify after deploying an instance from the AMI
+
+**To manually verify tuning on a deployed instance:**
+```bash
+# SSH into instance deployed from the AMI
+ssh -i ~/.ssh/your-key.pem ec2-user@<instance-ip>
+
+# Check tuning report
+sudo cat /root/trading_system_tuning_report.txt
+
+# Check THP
+cat /sys/kernel/mm/transparent_hugepage/enabled  # Should show [never]
+
+# Check CPU isolation
+cat /sys/devices/system/cpu/isolated  # Should show isolated cores
+
+# Check hugepages
+grep Huge /proc/meminfo  # Should show allocated pages
+
+# Check kernel parameters
+cat /proc/cmdline  # Should include isolcpus, nohz_full, etc.
+```
+
+## Advanced Usage
+
+### Building AMIs for Multiple Instance Types
+
+**Important**: The CPU isolation settings are **baked into the AMI at build time**. For optimal performance, build separate AMIs for different instance size classes:
+
+```bash
+# Build AMI for 16-32 vCPU instances
+./build-tuned-ami.sh --instance-type c7i.4xlarge --ami-name trading-16vcpu-v1
+
+# Build AMI for 48-96 vCPU instances
+./build-tuned-ami.sh --instance-type c7i.24xlarge --ami-name trading-96vcpu-v1
+
+# Build AMI for 128-192 vCPU instances
+./build-tuned-ami.sh --instance-type c7i.48xlarge --ami-name trading-192vcpu-v1
+```
+
+**Dynamic CPU Allocation at Build Time:**
+- The Ansible playbook detects the builder instance's vCPU count
+- Calculates optimal core allocation (housekeeping vs isolated)
+- Writes these settings to GRUB config (kernel boot parameters)
+- Settings are **baked into the AMI** and persist to instances launched from it
+
+**Recommended AMI Strategy:**
+
+| Instance Size | Build AMI On | Housekeeping | Isolated | Use For |
+|---------------|--------------|--------------|----------|---------|
+| Small (4-8 vCPUs) | c7i.2xlarge | 2 cores | 6 cores | Development/testing |
+| Medium (16-32 vCPUs) | c7i.4xlarge | 4 cores | 12-28 cores | Production (most common) |
+| Large (48-96 vCPUs) | c7i.24xlarge | 8 cores | 40-88 cores | High-throughput workloads |
+| X-Large (128-192 vCPUs) | c7i.48xlarge | 16 cores | 112-176 cores | Maximum performance |
+
+**Cross-Instance Compatibility:**
+- AMIs work across instance types but with suboptimal core allocation
+- Example: AMI built on c7i.4xlarge (16 vCPU) used on c7i.48xlarge (192 vCPU) will only isolate 12 cores instead of 176
+- For best performance: **Match AMI size class to deployment instance size**
+
+### Customizing Tuning Parameters
+
+To create AMIs with different tuning profiles:
+
+1. Modify `ansible/tune_os.yaml` to adjust parameters:
+   - `isolated_cores`: Change core isolation range
+   - `housekeeping_cores`: Adjust system task cores
+   - `busy_poll_value`: Tune busy polling behavior
+
+2. Build AMI with a descriptive name:
+   ```bash
+   ./build-tuned-ami.sh --ami-name trading-16core-v1
+   ```
+
+3. Document the configuration in AMI tags or description
+
+### Automating AMI Builds
+
+Integrate AMI building into CI/CD:
+
+```bash
+#!/bin/bash
+# ci-build-ami.sh
+
+# Exit on error
+set -e
+
+# Build AMI
+AMI_ID=$(./build-tuned-ami.sh \
+  --ami-name "trading-ami-$(git rev-parse --short HEAD)" \
+  --key-file "$SSH_KEY_PATH" | \
+  grep "AMI ID:" | awk '{print $3}')
+
+# Share AMI with other accounts
+aws ec2 modify-image-attribute \
+  --image-id "$AMI_ID" \
+  --launch-permission "Add=[{UserId=123456789012}]"
+
+# Export for subsequent steps
+echo "TUNED_AMI_ID=$AMI_ID" >> $GITHUB_OUTPUT
+```
+
+## Cleanup
+
+### Remove Old AMIs
+
+AMIs incur storage costs. Clean up old AMIs periodically:
+
+```bash
+# List your trading AMIs
+aws ec2 describe-images \
+  --owners self \
+  --filters "Name=name,Values=trading-benchmark-tuned-*" \
+  --query 'Images[*].[ImageId,Name,CreationDate]' \
+  --output table
+
+# Deregister an old AMI
+aws ec2 deregister-image --image-id ami-xxxxxxxxx
+
+# Delete associated snapshots
+aws ec2 describe-snapshots \
+  --owner-ids self \
+  --filters "Name=description,Values=*ami-xxxxxxxxx*" \
+  --query 'Snapshots[*].SnapshotId' \
+  --output text | xargs -n1 aws ec2 delete-snapshot --snapshot-id
+```
+
+### Clean Up Failed Builds
+
+If a build fails and leaves resources:
+
+```bash
+cd cdk
+cdk destroy TradingBenchmarkAmiBuilderStack --force
+
+# Or manually via AWS CLI
+aws ec2 describe-instances \
+  --filters "Name=tag:Purpose,Values=os-tuned-ami" "Name=instance-state-name,Values=running" \
+  --query 'Reservations[*].Instances[*].InstanceId' \
+  --output text | xargs -n1 aws ec2 terminate-instances --instance-ids
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     build-tuned-ami.sh                          │
+│                    (Orchestration Script)                       │
+└────────┬────────────────────────────────────────────────────────┘
+         │
+         ├─► Step 1: Deploy CDK Stack (ami-builder-stack.ts)
+         │   └─► Creates: VPC, Security Group, Single EC2 Instance
+         │
+         ├─► Step 2: Wait for Instance Ready
+         │   └─► SSH connectivity check
+         │
+         ├─► Step 3: Create Ansible Inventory
+         │   └─► Temporary inventory file with instance IP
+         │
+         ├─► Step 4: Run tune_os.yaml Playbook
+         │   └─► Applies all OS optimizations + automatic reboot
+         │
+         ├─► Step 5: Wait for Reboot Complete
+         │   └─► SSH connectivity check after reboot
+         │
+         ├─► Step 6: Create AMI
+         │   ├─► Stop instance
+         │   ├─► Create AMI from stopped instance
+         │   └─► Tag AMI with metadata
+         │
+         └─► Step 7: Cleanup (optional)
+             └─► Destroy CDK stack
+
+Output: AMI ID saved to ami-builder-latest.txt
+```
+
+## Support
+
+For issues or questions:
+1. Check the [main README](../README.md)
+2. Review the [CLAUDE.md](../CLAUDE.md) documentation
+3. Examine logs in the CDK outputs: `cdk/ami-builder-outputs.json`
+4. Check Ansible output for tuning errors
+5. Open an issue on GitHub
+
+## License
+
+This library is licensed under the MIT-0 License. See the LICENSE file.

--- a/deployment/ansible/inventory/inventory.aws_ec2.yml
+++ b/deployment/ansible/inventory/inventory.aws_ec2.yml
@@ -8,6 +8,7 @@ include_filters:
   - tag:Name:
     - 'Trading-Client'
     - 'Trading-Server'
+    - 'Trading-Benchmark-AMI-Builder-Instance'
 hostnames:
   - name: tag:Name
     separator: ''

--- a/deployment/ansible/tune_os.yaml
+++ b/deployment/ansible/tune_os.yaml
@@ -7,8 +7,6 @@
   
   vars:
     backup_dir: "/root/system_tuning_backup_{{ ansible_date_time.date }}"
-    isolated_cores: "2-7"  # Isolated cores for trading applications
-    housekeeping_cores: "0-1"  # Cores for system tasks and IRQs
     busy_poll_value: 50 # Adjust between 25-100
     busy_read_value: 50 # Adjust between 25-100
   
@@ -18,6 +16,44 @@
         path: "{{ backup_dir }}"
         state: directory
         mode: '0700'
+
+    # ==========================================
+    # DYNAMIC CPU CORE ALLOCATION
+    # ==========================================
+    - name: Detect number of vCPUs
+      ansible.builtin.set_fact:
+        total_vcpus: "{{ ansible_processor_vcpus }}"
+
+    - name: Calculate housekeeping and isolated cores based on instance size
+      ansible.builtin.set_fact:
+        # Scale housekeeping cores based on instance size
+        # 2-4 vCPUs: 1 core (0) - minimum viable
+        # 8 vCPUs: 2 cores (0-1)
+        # 16-32 vCPUs: 4 cores (0-3)
+        # 48-96 vCPUs: 8 cores (0-7)
+        # 128-192+ vCPUs: 16 cores (0-15)
+        housekeeping_core_count: >-
+          {% if total_vcpus|int <= 4 %}1
+          {% elif total_vcpus|int <= 8 %}2
+          {% elif total_vcpus|int <= 32 %}4
+          {% elif total_vcpus|int <= 96 %}8
+          {% else %}16
+          {% endif %}
+
+    - name: Set housekeeping and isolated core ranges
+      ansible.builtin.set_fact:
+        housekeeping_cores: >-
+          {% if housekeeping_core_count|int == 1 %}0
+          {% else %}0-{{ housekeeping_core_count|int - 1 }}
+          {% endif %}
+        isolated_cores: "{{ housekeeping_core_count }}-{{ total_vcpus|int - 1 }}"
+
+    - name: Display CPU allocation
+      ansible.builtin.debug:
+        msg:
+          - "Total vCPUs: {{ total_vcpus }}"
+          - "Housekeeping cores: {{ housekeeping_cores }} ({{ housekeeping_core_count }} cores for system tasks)"
+          - "Isolated cores: {{ isolated_cores }} ({{ total_vcpus|int - housekeeping_core_count|int }} cores for trading applications)"
 
     # ==========================================
     # PACKAGE INSTALLATION

--- a/deployment/build-tuned-ami.sh
+++ b/deployment/build-tuned-ami.sh
@@ -1,0 +1,424 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Script to build an OS-tuned AMI for trading applications
+# This script deploys a single EC2 instance, applies OS tuning, and creates an AMI
+
+set -e  # Exit on error
+
+# Configuration variables with defaults
+STACK_NAME="TradingBenchmarkAmiBuilderStack"
+INSTANCE_TYPE="${INSTANCE_TYPE:-c7i.4xlarge}"
+SSH_KEY_FILE="${SSH_KEY_FILE:-~/.ssh/tlb-demo.pem}"
+SSH_KEY_NAME="tlb-demo"
+REGION="${AWS_REGION:-us-east-1}"
+AMI_NAME_PREFIX="trading-benchmark-tuned"
+CLEANUP="${CLEANUP:-true}"
+MAX_WAIT_TIME=600  # 10 minutes
+ANSIBLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/ansible" && pwd)"
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to display usage information
+function show_usage() {
+    cat << EOF
+Usage: $0 [options]
+
+Build an OS-tuned AMI for trading applications by deploying an EC2 instance,
+running OS tuning optimizations, and creating an AMI from the tuned instance.
+
+Options:
+  -i, --instance-type TYPE    EC2 instance type to use (default: c7i.4xlarge)
+  -k, --key-file PATH         Path to SSH private key (default: ~/.ssh/virginia.pem)
+  -n, --ami-name NAME         Custom AMI name (default: trading-benchmark-tuned-TIMESTAMP)
+  -r, --region REGION         AWS region (default: us-east-1)
+  --no-cleanup                Keep the instance running after AMI creation
+  -h, --help                  Show this help message
+
+Environment Variables:
+  INSTANCE_TYPE               EC2 instance type (same as --instance-type)
+  SSH_KEY_FILE                Path to SSH key (same as --key-file)
+  AWS_REGION                  AWS region (same as --region)
+  CLEANUP                     Set to 'false' to keep instance (same as --no-cleanup)
+
+Example:
+  $0 --instance-type c7i.4xlarge --key-file ~/.ssh/my-key.pem
+
+EOF
+}
+
+# Parse command line arguments
+CUSTOM_AMI_NAME=""
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -i|--instance-type)
+            INSTANCE_TYPE="$2"
+            shift 2
+            ;;
+        -k|--key-file)
+            SSH_KEY_FILE="$2"
+            shift 2
+            ;;
+        -n|--ami-name)
+            CUSTOM_AMI_NAME="$2"
+            shift 2
+            ;;
+        -r|--region)
+            REGION="$2"
+            shift 2
+            ;;
+        --no-cleanup)
+            CLEANUP="false"
+            shift
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
+# Validate SSH key file
+SSH_KEY_FILE=$(eval echo "$SSH_KEY_FILE")
+if [ ! -f "$SSH_KEY_FILE" ]; then
+    echo -e "${RED}Error: SSH key file not found: $SSH_KEY_FILE${NC}"
+    exit 1
+fi
+
+# Derive SSH_KEY_NAME from SSH_KEY_FILE if not set
+# Extract filename without path and .pem extension
+if [ -z "$SSH_KEY_NAME" ]; then
+    SSH_KEY_NAME=$(basename "$SSH_KEY_FILE" .pem)
+fi
+
+# Set AMI name
+if [ -z "$CUSTOM_AMI_NAME" ]; then
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    AMI_NAME="${AMI_NAME_PREFIX}-${TIMESTAMP}"
+else
+    AMI_NAME="$CUSTOM_AMI_NAME"
+fi
+
+echo -e "${GREEN}======================================================${NC}"
+echo -e "${GREEN}Trading Benchmark AMI Builder${NC}"
+echo -e "${GREEN}======================================================${NC}"
+echo "Instance Type: $INSTANCE_TYPE"
+echo "SSH Key File: $SSH_KEY_FILE"
+echo "SSH Key Name: $SSH_KEY_NAME"
+echo "Region: $REGION"
+echo "AMI Name: $AMI_NAME"
+echo "Cleanup After: $CLEANUP"
+echo -e "${GREEN}======================================================${NC}"
+
+# Step 1: Deploy CDK stack
+echo -e "\n${YELLOW}[Step 1/7] Deploying CDK stack...${NC}"
+cd "$(dirname "${BASH_SOURCE[0]}")/cdk"
+
+# Check if node_modules exists, if not run npm install
+if [ ! -d "node_modules" ]; then
+    echo "Installing CDK dependencies..."
+    npm install
+fi
+
+# Deploy the AMI builder stack
+echo "Deploying AMI builder stack..."
+cdk deploy $STACK_NAME \
+    --context deploymentType=ami-builder \
+    --context instanceType="$INSTANCE_TYPE" \
+    --context keyPairName="$SSH_KEY_NAME" \
+    --require-approval never \
+    --outputs-file ./ami-builder-outputs.json
+
+# Extract outputs
+INSTANCE_ID=$(jq -r ".${STACK_NAME}.InstanceId" ./ami-builder-outputs.json)
+INSTANCE_IP=$(jq -r ".${STACK_NAME}.InstancePublicIp" ./ami-builder-outputs.json)
+
+if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" == "null" ]; then
+    echo -e "${RED}Error: Failed to get instance ID from CDK outputs${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Instance deployed: $INSTANCE_ID ($INSTANCE_IP)${NC}"
+
+# Step 2: Wait for instance to be running and ready
+echo -e "\n${YELLOW}[Step 2/7] Waiting for instance to be ready...${NC}"
+echo "Waiting for instance status checks..."
+aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID" --region "$REGION" || {
+    echo -e "${RED}Warning: Instance status check wait timed out, continuing anyway...${NC}"
+}
+
+# Wait for SSH to be available
+echo "Waiting for SSH to be available..."
+ELAPSED=0
+while ! ssh -i "$SSH_KEY_FILE" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=5 \
+    -q ec2-user@"$INSTANCE_IP" exit 2>/dev/null; do
+
+    if [ $ELAPSED -ge $MAX_WAIT_TIME ]; then
+        echo -e "${RED}Error: Timeout waiting for SSH access${NC}"
+        exit 1
+    fi
+
+    echo "Waiting for SSH... ($ELAPSED seconds elapsed)"
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+done
+
+echo -e "${GREEN}Instance is ready and SSH is accessible${NC}"
+
+# Step 3: Create temporary Ansible inventory
+echo -e "\n${YELLOW}[Step 3/7] Creating Ansible inventory...${NC}"
+TEMP_INVENTORY=$(mktemp)
+cat > "$TEMP_INVENTORY" << EOF
+[aws_ec2]
+$INSTANCE_IP ansible_user=ec2-user ansible_ssh_private_key_file=$SSH_KEY_FILE ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+EOF
+
+echo "Temporary inventory created at: $TEMP_INVENTORY"
+
+# Step 4: Run OS tuning playbook
+echo -e "\n${YELLOW}[Step 4/7] Running OS tuning playbook...${NC}"
+echo "This will take several minutes and will reboot the instance..."
+cd "$ANSIBLE_DIR"
+
+# Check if instance is in dynamic inventory
+# The inventory hostname is based on the Name tag
+INVENTORY_HOSTNAME="Trading-Benchmark-AMI-Builder-Instance"
+echo "Verifying instance is discoverable in Ansible inventory..."
+echo "Looking for host: $INVENTORY_HOSTNAME"
+ANSIBLE_INVENTORY_CHECK=$(ansible-inventory -i ./inventory/inventory.aws_ec2.yml --list 2>&1 | grep -c "$INVENTORY_HOSTNAME" || true)
+if [ "$ANSIBLE_INVENTORY_CHECK" -eq 0 ]; then
+    echo -e "${RED}Error: Host '$INVENTORY_HOSTNAME' not found in dynamic inventory${NC}"
+    echo -e "${YELLOW}Make sure the instance has the tag 'Name: Trading-Benchmark-AMI-Builder-Instance'${NC}"
+    echo -e "${YELLOW}Checking current inventory...${NC}"
+    ansible-inventory -i ./inventory/inventory.aws_ec2.yml --graph
+    rm -f "$TEMP_INVENTORY"
+    exit 1
+fi
+echo -e "${GREEN}Host '$INVENTORY_HOSTNAME' found in inventory (IP: $INSTANCE_IP)${NC}"
+
+# Run the tune_os.yaml playbook using dynamic inventory
+echo "Running OS tuning playbook on host: $INVENTORY_HOSTNAME"
+ANSIBLE_OUTPUT=$(mktemp)
+ansible-playbook tune_os.yaml \
+    -i ./inventory/inventory.aws_ec2.yml \
+    --key-file "$SSH_KEY_FILE" \
+    -e "ansible_host_key_checking=False" \
+    --limit "$INVENTORY_HOSTNAME" 2>&1 | tee "$ANSIBLE_OUTPUT"
+
+ANSIBLE_EXIT_CODE=${PIPESTATUS[0]}
+if [ $ANSIBLE_EXIT_CODE -ne 0 ]; then
+    echo -e "${RED}Error: Ansible playbook failed with exit code $ANSIBLE_EXIT_CODE${NC}"
+    echo "Check output above for details"
+    rm -f "$TEMP_INVENTORY" "$ANSIBLE_OUTPUT"
+    exit 1
+fi
+
+# Verify playbook ran on at least one host
+HOSTS_CHANGED=$(grep -c "ok=" "$ANSIBLE_OUTPUT" || true)
+if [ "$HOSTS_CHANGED" -eq 0 ]; then
+    echo -e "${RED}Error: Ansible playbook did not run on any hosts${NC}"
+    echo "Playbook output:"
+    cat "$ANSIBLE_OUTPUT"
+    rm -f "$TEMP_INVENTORY" "$ANSIBLE_OUTPUT"
+    exit 1
+fi
+
+rm -f "$ANSIBLE_OUTPUT"
+echo -e "${GREEN}OS tuning completed successfully${NC}"
+
+# Step 5: Wait for instance to be back online after reboot
+echo -e "\n${YELLOW}[Step 5/7] Waiting for instance to come back online after reboot...${NC}"
+sleep 30  # Give it some time to start rebooting
+
+ELAPSED=0
+while ! ssh -i "$SSH_KEY_FILE" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=5 \
+    -q ec2-user@"$INSTANCE_IP" exit 2>/dev/null; do
+
+    if [ $ELAPSED -ge $MAX_WAIT_TIME ]; then
+        echo -e "${RED}Error: Timeout waiting for instance to come back online${NC}"
+        rm -f "$TEMP_INVENTORY"
+        exit 1
+    fi
+
+    echo "Waiting for instance to come back online... ($ELAPSED seconds elapsed)"
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+done
+
+echo -e "${GREEN}Instance is back online${NC}"
+
+# Give the system a bit more time to fully stabilize
+echo "Waiting for system to stabilize..."
+sleep 30
+
+# Verify tuning was applied
+echo "Verifying OS tuning..."
+
+# Check if tuning report exists
+TUNING_REPORT_EXISTS=$(ssh -i "$SSH_KEY_FILE" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    ec2-user@"$INSTANCE_IP" \
+    "sudo test -f /root/trading_system_tuning_report.txt && echo 'exists' || echo 'missing'" 2>/dev/null)
+
+if [ "$TUNING_REPORT_EXISTS" != "exists" ]; then
+    echo -e "${RED}Error: OS tuning report not found on instance${NC}"
+    echo -e "${RED}This indicates the tune_os.yaml playbook did not complete successfully${NC}"
+    rm -f "$TEMP_INVENTORY"
+    exit 1
+fi
+echo -e "${GREEN}✓ Tuning report found${NC}"
+
+# Verify specific tuning markers
+echo "Checking tuning markers..."
+VERIFICATION_FAILED=0
+
+# Check THP is disabled
+THP_STATUS=$(ssh -i "$SSH_KEY_FILE" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    ec2-user@"$INSTANCE_IP" \
+    "cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || echo 'error'")
+
+if echo "$THP_STATUS" | grep -q "never"; then
+    echo -e "${GREEN}✓ Transparent Huge Pages disabled${NC}"
+else
+    echo -e "${YELLOW}⚠ THP status: $THP_STATUS${NC}"
+    VERIFICATION_FAILED=1
+fi
+
+# Check CPU isolation
+CPU_ISOLATED=$(ssh -i "$SSH_KEY_FILE" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    ec2-user@"$INSTANCE_IP" \
+    "cat /sys/devices/system/cpu/isolated 2>/dev/null || echo 'error'")
+
+if [ "$CPU_ISOLATED" != "error" ] && [ -n "$CPU_ISOLATED" ]; then
+    echo -e "${GREEN}✓ CPU cores isolated: $CPU_ISOLATED${NC}"
+else
+    echo -e "${YELLOW}⚠ CPU isolation not detected (may require reboot to take effect)${NC}"
+fi
+
+# Check hugepages
+HUGEPAGES=$(ssh -i "$SSH_KEY_FILE" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    ec2-user@"$INSTANCE_IP" \
+    "grep HugePages_Total /proc/meminfo | awk '{print \$2}' 2>/dev/null || echo '0'")
+
+if [ "$HUGEPAGES" -gt 0 ]; then
+    echo -e "${GREEN}✓ Hugepages configured: $HUGEPAGES pages${NC}"
+else
+    echo -e "${YELLOW}⚠ Hugepages not detected${NC}"
+    VERIFICATION_FAILED=1
+fi
+
+if [ $VERIFICATION_FAILED -eq 1 ]; then
+    echo -e "${YELLOW}Warning: Some tuning verifications failed, but continuing...${NC}"
+    echo -e "${YELLOW}The AMI may need a reboot for all settings to take effect${NC}"
+fi
+
+echo -e "${GREEN}OS tuning verification completed${NC}"
+
+# Clean up temporary inventory
+rm -f "$TEMP_INVENTORY"
+
+# Step 6: Stop instance and create AMI
+echo -e "\n${YELLOW}[Step 6/7] Stopping instance and creating AMI...${NC}"
+echo "Stopping instance..."
+aws ec2 stop-instances --instance-ids "$INSTANCE_ID" --region "$REGION" > /dev/null
+aws ec2 wait instance-stopped --instance-ids "$INSTANCE_ID" --region "$REGION"
+echo -e "${GREEN}Instance stopped${NC}"
+
+echo "Creating AMI: $AMI_NAME"
+AMI_ID=$(aws ec2 create-image \
+    --instance-id "$INSTANCE_ID" \
+    --name "$AMI_NAME" \
+    --description "OS-tuned AMI for trading applications (built from $INSTANCE_TYPE)" \
+    --tag-specifications "ResourceType=image,Tags=[{Key=Name,Value=$AMI_NAME},{Key=Purpose,Value=trading-benchmark},{Key=Tuned,Value=true}]" \
+    --region "$REGION" \
+    --output text \
+    --query 'ImageId')
+
+if [ -z "$AMI_ID" ] || [ "$AMI_ID" == "None" ]; then
+    echo -e "${RED}Error: Failed to create AMI${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}AMI creation initiated: $AMI_ID${NC}"
+echo "Waiting for AMI to be available (this may take several minutes)..."
+aws ec2 wait image-available --image-ids "$AMI_ID" --region "$REGION"
+echo -e "${GREEN}AMI is now available!${NC}"
+
+# Step 7: Clean up
+if [ "$CLEANUP" == "true" ]; then
+    echo -e "\n${YELLOW}[Step 7/7] Cleaning up resources...${NC}"
+
+    # Use CloudFormation to delete stack (more reliable than CDK with version mismatches)
+    echo "Destroying CDK stack via CloudFormation..."
+    aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION"
+
+    echo "Waiting for stack deletion to complete..."
+    aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || {
+        echo -e "${YELLOW}Note: Stack deletion initiated but may still be in progress${NC}"
+    }
+
+    # Clean up output file
+    CDK_DIR="$(dirname "${BASH_SOURCE[0]}")/cdk"
+    rm -f "$CDK_DIR/ami-builder-outputs.json"
+
+    echo -e "${GREEN}Cleanup completed${NC}"
+else
+    echo -e "\n${YELLOW}[Step 7/7] Skipping cleanup (instance will remain running)${NC}"
+    echo "Instance ID: $INSTANCE_ID"
+    echo "Instance IP: $INSTANCE_IP"
+    echo ""
+    echo "To destroy the stack later, run:"
+    echo "  cd deployment/cdk && cdk destroy $STACK_NAME"
+fi
+
+# Final output
+echo ""
+echo -e "${GREEN}======================================================${NC}"
+echo -e "${GREEN}AMI BUILD COMPLETE!${NC}"
+echo -e "${GREEN}======================================================${NC}"
+echo "AMI ID: $AMI_ID"
+echo "AMI Name: $AMI_NAME"
+echo "Region: $REGION"
+echo ""
+echo "You can now use this AMI in your deployments:"
+echo "  cdk deploy --context baseAmi=$AMI_ID"
+echo ""
+echo "Or reference it in your CDK code:"
+echo "  MachineImage.genericLinux({ '$REGION': '$AMI_ID' })"
+echo -e "${GREEN}======================================================${NC}"
+
+# Save AMI ID to a file for easy reference
+AMI_INFO_FILE="$(dirname "${BASH_SOURCE[0]}")/ami-builder-latest.txt"
+cat > "$AMI_INFO_FILE" << EOF
+AMI_ID=$AMI_ID
+AMI_NAME=$AMI_NAME
+REGION=$REGION
+INSTANCE_TYPE=$INSTANCE_TYPE
+BUILD_DATE=$(date)
+EOF
+
+echo "AMI details saved to: $AMI_INFO_FILE"

--- a/deployment/cdk/bin/trading-benchmark.ts
+++ b/deployment/cdk/bin/trading-benchmark.ts
@@ -4,6 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 import { TradingBenchmarkMultiAzStack } from '../lib/multi-az-stack';
 import { TradingBenchmarkSingleInstanceStack } from "../lib/single-instance-stack";
 import { TradingBenchmarkClusterPlacementGroupStack } from "../lib/cluster-placement-group-stack";
+import { TradingBenchmarkAmiBuilderStack } from "../lib/ami-builder-stack";
 
 const app = new cdk.App();
 
@@ -14,6 +15,8 @@ const serverInstanceType = app.node.tryGetContext('serverInstanceType');
 const instanceType1 = app.node.tryGetContext('instanceType1');
 const instanceType2 = app.node.tryGetContext('instanceType2');
 const instanceType = app.node.tryGetContext('instanceType');
+const baseAmi = app.node.tryGetContext('baseAmi');
+const keyPairName = app.node.tryGetContext('keyPairName');
 
 // Environment configuration
 const env = {
@@ -22,6 +25,16 @@ const env = {
 
 // Deploy the appropriate stack based on the deployment type
 switch (deploymentType.toLowerCase()) {
+  case 'ami-builder':
+    console.log('Deploying Trading Benchmark AMI Builder Stack');
+    new TradingBenchmarkAmiBuilderStack(app, 'TradingBenchmarkAmiBuilderStack', {
+      env,
+      instanceType,
+      baseAmi,
+      keyPairName
+    });
+    break;
+
   case 'cluster':
   case 'placement-group':
   case 'cpg':
@@ -32,7 +45,7 @@ switch (deploymentType.toLowerCase()) {
       serverInstanceType
     });
     break;
-  
+
   case 'multi-az':
     console.log('Deploying Trading Benchmark Multi-AZ Stack');
     new TradingBenchmarkMultiAzStack(app, 'TradingBenchmarkMultiAzStack', {
@@ -40,7 +53,7 @@ switch (deploymentType.toLowerCase()) {
       instanceType
     });
     break;
-  
+
   case 'single':
   default:
     console.log('Deploying Trading Benchmark Single Instance Stack');

--- a/deployment/cdk/lib/ami-builder-stack.ts
+++ b/deployment/cdk/lib/ami-builder-stack.ts
@@ -1,0 +1,117 @@
+import * as cdk from 'aws-cdk-lib';
+import { Vpc, SubnetType, Instance, InstanceType, MachineImage, SecurityGroup, Port, Peer, BlockDeviceVolume, KeyPair } from 'aws-cdk-lib/aws-ec2';
+import { RemovalPolicy } from 'aws-cdk-lib';
+
+export interface TradingBenchmarkAmiBuilderStackProps extends cdk.StackProps {
+    instanceType?: string;
+    baseAmi?: string;
+    keyPairName?: string;
+}
+
+/**
+ * CDK Stack for building an OS-tuned AMI for trading applications.
+ * Deploys a single EC2 instance that will be tuned and converted to an AMI.
+ */
+export class TradingBenchmarkAmiBuilderStack extends cdk.Stack {
+    public readonly instance: Instance;
+    public readonly instanceId: cdk.CfnOutput;
+    public readonly instancePublicIp: cdk.CfnOutput;
+
+    constructor(scope: cdk.App, id: string, props?: TradingBenchmarkAmiBuilderStackProps) {
+        super(scope, id, props);
+
+        // Default instance type if not provided - use a common type for AMI building
+        const instanceType = props?.instanceType || 'c7i.4xlarge';
+
+        // Create a minimal VPC for AMI building
+        const vpc = new Vpc(this, 'AmiBuilderVPC', {
+            natGateways: 0, // No NAT gateway needed - use public subnet
+            availabilityZones: ['us-east-1a'],
+            subnetConfiguration: [
+                {
+                    cidrMask: 24,
+                    name: 'Public',
+                    subnetType: SubnetType.PUBLIC,
+                    mapPublicIpOnLaunch: true
+                }
+            ],
+            gatewayEndpoints: {}
+        });
+
+        // Apply removal policy to make cleanup easier
+        vpc.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+        // Security group allowing SSH access
+        const securityGroup = new SecurityGroup(this, 'AmiBuilderSecurityGroup', {
+            vpc,
+            description: 'Allow SSH access for AMI builder instance',
+            allowAllOutbound: true,
+        });
+
+        securityGroup.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+        securityGroup.addIngressRule(
+            Peer.anyIpv4(),
+            Port.tcp(22),
+            'Allow SSH access for configuration'
+        );
+
+        // Use base AMI if specified, otherwise use latest Amazon Linux 2023
+        const ami = props?.baseAmi
+            ? MachineImage.genericLinux({ 'us-east-1': props.baseAmi })
+            : MachineImage.latestAmazonLinux2023();
+
+        // Import existing key pair
+        const keyPairName = props?.keyPairName || 'virginia';
+        const keyPair = KeyPair.fromKeyPairName(this, 'ImportedKeyPair', keyPairName);
+
+        // Parse instance type
+        let instanceTypeObj: InstanceType;
+        try {
+            instanceTypeObj = new InstanceType(instanceType);
+        } catch (error) {
+            console.warn(`Could not parse instance type ${instanceType}, using default: c7i.4xlarge`);
+            instanceTypeObj = new InstanceType('c7i.4xlarge');
+        }
+
+        // Create single instance for AMI building
+        this.instance = new Instance(this, 'AmiBuilderInstance', {
+            vpc,
+            instanceType: instanceTypeObj,
+            machineImage: ami,
+            securityGroup,
+            vpcSubnets: {
+                availabilityZones: ['us-east-1a'],
+                subnetType: SubnetType.PUBLIC
+            },
+            keyPair,
+            blockDevices: [{
+                deviceName: "/dev/xvda",
+                volume: BlockDeviceVolume.ebs(512, {
+                    deleteOnTermination: true
+                })
+            }]
+        });
+
+        // Apply removal policy
+        this.instance.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+        // Add tags to identify the AMI builder instance
+        cdk.Tags.of(this.instance).add('Name', 'Trading-Benchmark-AMI-Builder-Instance');
+        cdk.Tags.of(this.instance).add('Role', 'ami-builder');
+        cdk.Tags.of(this.instance).add('Purpose', 'os-tuned-ami');
+
+        // Output the instance ID and public IP for use by orchestration script
+        this.instanceId = new cdk.CfnOutput(this, 'InstanceId', {
+            value: this.instance.instanceId,
+            description: 'AMI Builder Instance ID',
+            exportName: 'AmiBuilderInstanceId'
+        });
+
+        this.instancePublicIp = new cdk.CfnOutput(this, 'InstancePublicIp', {
+            value: this.instance.instancePublicIp,
+            description: 'AMI Builder Instance Public IP',
+            exportName: 'AmiBuilderInstancePublicIp'
+        });
+    }
+}


### PR DESCRIPTION
New AMI Builder Feature:
- Add build-tuned-ami.sh orchestration script with 7-step workflow
- Add ami-builder-stack.ts CDK stack for single instance deployment
- Add comprehensive AMI builder documentation
- Update README with AMI builder quick start guide

OS Tuning Enhancements:
- Implement dynamic CPU core allocation in tune_os.yaml
- Auto-detect vCPU count and scale housekeeping cores appropriately
- Support instances from 2 to 192 vCPUs (t3.medium to c7i.48xlarge)

Benefits:
- 10x faster deployments (~2 min vs ~25 min with manual tuning)
- Consistent OS optimizations across all instances
- Automatic core allocation eliminates manual configuration

Fixes #45

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License].

[MIT-0 License]: https://github.com/aws/mit-0
